### PR TITLE
Add support for rejected option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ Type: `Array<RegExp>`
 
 You can whitelist selectors based on a regular expression with whitelistPatterns.
 
+### `rejected`
+Type: `boolean`
+Default value: `false`
+
+If true, purged selectors will be captured and rendered as PostCSS messages.
+Use with a PostCSS reporter plugin like [`postcss-reporter`](https://github.com/postcss/postcss-reporter)
+to print the purged selectors to the console as they are processed.
+
 ### `keyframes`
 Type: `boolean`
 Default value: `false`

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -28,6 +28,32 @@ describe('Purgecss postcss plugin', () => {
         })
     }
 
+    for (const file of files) {
+        it(`queues messages when using reject flag: ${file}`, done => {
+            const input = fs
+                .readFileSync(`${__dirname}/fixtures/src/${file}/${file}.css`)
+                .toString()
+            const expected = fs
+                .readFileSync(`${__dirname}/fixtures/expected/${file}.css`)
+                .toString()
+            postcss([
+                purgecss({
+                    content: [`${__dirname}/fixtures/src/${file}/${file}.html`],
+                    rejected: true
+                })
+            ])
+                .process(input)
+                .then(result => {
+                    expect(result.css).toBe(expected)
+                    expect(result.warnings().length).toBe(0)
+                    expect(result.messages.length).toBeGreaterThan(0)
+                    expect(result.messages[0].text).toMatch(/unused-class/)
+                    expect(result.messages[0].text).toMatch(/another-one-not-found/)
+                    done()
+                })
+        })
+    }
+
     it('remove unused css with config file', done => {
         const input = fs
             .readFileSync(`${__dirname}/fixtures/src/simple/simple.css`)

--- a/lib/postcss-purgecss.es.js
+++ b/lib/postcss-purgecss.es.js
@@ -54,7 +54,7 @@ var loadConfigFile = function loadConfigFile(configFile) {
 };
 
 var index = postcss.plugin('postcss-plugin-purgecss', function (opts) {
-  return function (root) {
+  return function (root, result) {
     if (typeof opts === 'string' || typeof opts === 'undefined') opts = loadConfigFile(opts);
 
     if (!opts.css || !opts.css.length) {
@@ -83,6 +83,17 @@ var index = postcss.plugin('postcss-plugin-purgecss', function (opts) {
     if (purgecss.options.keyframes) purgecss.removeUnusedKeyframes(); // purge font face
 
     if (purgecss.options.fontFace) purgecss.removeUnusedFontFaces();
+
+    if (purgecss.options.rejected && purgecss.selectorsRemoved.size > 0) {
+      result.messages.push({
+        type: 'purgecss',
+        plugin: 'postcss-purgecss',
+        text: "purging ".concat(purgecss.selectorsRemoved.size, " selectors:\n  ").concat(Array.from(purgecss.selectorsRemoved).map(function (selector) {
+          return selector.trim();
+        }).join('\n  '))
+      });
+      purgecss.selectorsRemoved.clear();
+    }
   };
 });
 

--- a/lib/postcss-purgecss.js
+++ b/lib/postcss-purgecss.js
@@ -58,7 +58,7 @@ var loadConfigFile = function loadConfigFile(configFile) {
 };
 
 var index = postcss.plugin('postcss-plugin-purgecss', function (opts) {
-  return function (root) {
+  return function (root, result) {
     if (typeof opts === 'string' || typeof opts === 'undefined') opts = loadConfigFile(opts);
 
     if (!opts.css || !opts.css.length) {
@@ -87,6 +87,17 @@ var index = postcss.plugin('postcss-plugin-purgecss', function (opts) {
     if (purgecss.options.keyframes) purgecss.removeUnusedKeyframes(); // purge font face
 
     if (purgecss.options.fontFace) purgecss.removeUnusedFontFaces();
+
+    if (purgecss.options.rejected && purgecss.selectorsRemoved.size > 0) {
+      result.messages.push({
+        type: 'purgecss',
+        plugin: 'postcss-purgecss',
+        text: "purging ".concat(purgecss.selectorsRemoved.size, " selectors:\n  ").concat(Array.from(purgecss.selectorsRemoved).map(function (selector) {
+          return selector.trim();
+        }).join('\n  '))
+      });
+      purgecss.selectorsRemoved.clear();
+    }
   };
 });
 

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ const loadConfigFile = configFile => {
 }
 
 export default postcss.plugin('postcss-plugin-purgecss', function(opts) {
-    return function(root) {
+    return function(root, result) {
         if (typeof opts === 'string' || typeof opts === 'undefined')
             opts = loadConfigFile(opts)
 
@@ -62,5 +62,15 @@ export default postcss.plugin('postcss-plugin-purgecss', function(opts) {
 
         // purge font face
         if (purgecss.options.fontFace) purgecss.removeUnusedFontFaces()
+
+        if (purgecss.options.rejected && purgecss.selectorsRemoved.size > 0) {
+            result.messages.push({
+                type: 'purgecss',
+                plugin: 'postcss-purgecss',
+                text: `purging ${purgecss.selectorsRemoved.size} selectors:
+  ${Array.from(purgecss.selectorsRemoved).map(selector => selector.trim()).join('\n  ')}`,
+            })
+            purgecss.selectorsRemoved.clear()
+        }
     }
 })


### PR DESCRIPTION
Push rejected selectors onto `result.messages` for downstream consumption.  Use with a PostCSS reporter plugin like [`postcss-reporter`](https://github.com/postcss/postcss-reporter) to print the purged selectors to the console as they are processed.

Addressed Issue #16.