### PR TITLE
feat(content-options): Allow content option to be specified as function that is evaluated per input source file

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,24 @@ All of the options of purgecss are available to use with the plugins.
 You will find below the main options available. For the complete list, go to the [purgecss documentation website](https://www.purgecss.com/configuration.html#options).
 
 ### `content` (**required**)
-Type: `string | Object`
+Type: `Array<string>`
 
 You can specify content that should be analyzed by Purgecss with an array of filenames or globs. The files can be HTML, Pug, Blade, etc.
+
+Type: `(sourceInputFile: string) => Array<string>`
+
+content may be a function that returns the array of globs. The function receives the current source input file. With this you may provide a
+specific array of globs for each input. E.g. for an angular application only scan the components template counterpart for every component scss file:
+
+```js
+purgecss({
+  content: (source: string) => {
+    (/component\.scss$/.test(source))
+      ? [sourceInputFile.replace(/scss$/, 'html')]
+      : ['./src/**/*.html']
+  },
+})
+```
 
 ### `extractors`
 Type: `Array<Object>`

--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,11 @@ export default postcss.plugin('postcss-plugin-purgecss', function(opts) {
         purgecss.root = root
 
         // Get selectors from content files
-        const { content, extractors } = purgecss.options
+        let { content, extractors } = purgecss.options
+
+        if (typeof content === 'function') {
+            content = content(root.source.input.file)
+        }
 
         const fileFormatContents = ((content.filter(
             o => typeof o === 'string'


### PR DESCRIPTION
Hey, love your addon 👍. We use it at rebuy.de for our angular application.

I'd like to be able to specify the content option as a function - in a fully backwards compatible way of course - see the added part in the README.md:

-- 

### `content` (**required**)

Type: `(sourceInputFile: string) => Array<string>`

content may be a function that returns the array of globs. The function receives the current source input file. With this you may provide a specific array of globs for each input. E.g. for an angular application only scan the components template counterpart for every component scss file:

```js
purgecss({
  content: (source: string) => {
    (/component\.scss$/.test(source))
      ? [sourceInputFile.replace(/scss$/, 'html')]
      : ['./src/**/*.html']
  },
})
```

--

In our case this would be:
1. faster (100ms instead of currently 20 sec.) - we right now have 125 components with 125 scss entry files
2. more accurate, as the specific globs will only use the tokens from the related template